### PR TITLE
update: Disable deprecated 'Week In Ethereum' link and add tooltip with explanation (#300)

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,7 +550,10 @@ And finally, by embarking on this journey, you are now a "Security Researcher", 
 * [Blockchain Threat Intelligence](https://newsletter.blockthreat.io?r=2mgsm7) (Referral link)
 * [Solodit (not a newsletter, but has constant updates of new hacks)](https://solodit.xyz/)
 * [rekt](https://rekt.news/)
-* [Week In Ethereum](https://weekinethereumnews.com/)
+* <span style="color: gray; text-decoration: none; cursor: default;" title="Week in Ethereum has ended.">
+    Week In Ethereum
+  </span> 
+  <a href="https://weekinethereum.substack.com/" target="_blank" style="margin-left: 6px; hover: underline; color: lightblue;">(here's why)</a>
 * [Consensys Diligence Newsletter](https://consensys.io/diligence/newsletter/)
 * [Officer CIA](https://officercia.mirror.xyz/)
 


### PR DESCRIPTION
This PR addresses an update to the official Cyfrin Security and Auditing Full Course [README](https://github.com/Cyfrin/security-and-auditing-full-course-s23), specifically in Section 2 under the exercise:
📝 Exercise: Sign up for one security/web3 newsletter!

![Screenshot from 2025-03-30 11-32-47](https://github.com/user-attachments/assets/acac7608-709f-4032-8c26-708f4193c262)

**Changes Made:**
1. Disabled "Week in Ethereum" Link:
- The fifth link, "Week in Ethereum," can no longer be recommended in the documentation as it has lost its last remaining support from the Ethereum Foundation and is now deprecated ([source](https://weekinethereum.substack.com/)).
- Instead of removing it entirely, I **disabled the link** and **greyed out the text** to visually differentiate it from active recommendations.
![Screenshot from 2025-03-30 12-04-44](https://github.com/user-attachments/assets/253d7cb9-9700-4d45-b15b-1843b63630b5)
- Added a hover title explaining why it is disabled.
![Screenshot from 2025-03-30 11-35-30](https://github.com/user-attachments/assets/9500e4ea-e986-4cf3-a701-d671e4b92148)

2. Preserved Historical Context:
- The item remains in the repo as it was previously recommended for staying updated on web3 hacks (Section 2 exercises).
- It also appears in the Cyfrin Security Auditing Course YouTube videos at the time of this PR.
- A future update will remove it completely once the latest Cyfrin Auditing Course video is released.

**Justification:**
- Removing it entirely at this stage would be too disruptive, given its historical relevance in the course material.
- The current approach maintains transparency while guiding users toward active resources.