### PR TITLE
Fix README navigation links and update Coinbase asset guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,7 +619,7 @@ For this demo, we are ignoring the last 2 phases
 ## The Setup (Scoping): PasswordStore
 ## V1
   - "Hey, here is my link to Etherscan, can I get an audit?"
-    - [Coinbase asset listing guide](https://www.coinbase.com/blog/a-guide-to-listing-assets-on-coinbase)
+    - [Coinbase asset listing guide](https://www.coinbase.com/blog/A-Guide-to-the-Digital-Asset-Listing-Process-at-Coinbase)
 ### V2
   - Client onboarding: Minimal
 ### V3


### PR DESCRIPTION
Most of the changes can be checked and understood right away from the `file changed` section. It's just some of them might need a bit of a write-up here:

1. **Changing `Security Review > Audit` to `The Setup (Scoping): PasswordStore`**: There isn't any section mentioned as `Security Review > Audit` under [PasswordStore](https://github.com/Cyfrin/security-and-auditing-full-course-s23?tab=readme-ov-file#%EF%B8%8F-section-3-your-first-audit-security-review--passwordstore-audit). Instead, the stuff regarding Security Reviews (i.e., Security Review CodeV1, etc.) falls under the main heading -> `⛳️ Section 3: Your first audit | PasswordStore Audit`. Additionally, there was no section designated as `The Setup (Scoping): PasswordStore` in the Table of Contents, despite it being created under `PasswordStore`.

2. **Swapping `Writing your first finding` and `Exploits: Private Data`**: These two sections were placed in the wrong order under the Table of Contents.

3. **Updated the Coinbase Asset Guide Link**: The [previous link](https://www.coinbase.com/blog/a-guide-to-listing-assets-on-coinbase) led me to the main Coinbase blog site rather than the actual `listing assets` blog. Feels like they have either updated the previous one or removed it and created a [new one](https://www.coinbase.com/blog/A-Guide-to-the-Digital-Asset-Listing-Process-at-Coinbase) instead. That's why it's better to update it here.