### PR TITLE
Fix broken links

### DIFF
--- a/chronological-updates.md
+++ b/chronological-updates.md
@@ -1,1 +1,1 @@
-Please visit [Cyfrin Updraft](https://web3education.dev/) for updates to the course content. 
+Please visit [Cyfrin Updraft](https://updraft.cyfrin.io/) for updates to the course content. 


### PR DESCRIPTION
  Replace the outdated web3education.dev link in chronological-updates.md with the current https://updraft.cyfrin.io/ URL to match the rest of the docs and avoid redirects/broken navigation