### PR TITLE
fix: Update Google Bard link to Gemini

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Join [Cyfrin Updraft](https://updraft.cyfrin.io/) for the best learning experien
       - Just know that it will often get things wrong, but it's very fast!
   - [Phind](https://www.phind.com/)
       - Like ChatGPT, but it searches the web
-  - [Bard](https://bard.google.com/)
+  - [Gemini](https://gemini.google.com/)
   - [Other AI extensions](https://twitter.com/aisolopreneur/status/1654823630155464704?s=42&t=-pu_sCYtfrfPJU7OXfifrQ)
   - [devdacian - ai auditor primers](https://github.com/devdacian/ai-auditor-primers) - Collection of prompts to improve LLM performance for smart contracts from cyfrin's lead auditor 
 - Github Discussions 


### PR DESCRIPTION
 Updates the outdated Google Bard AI link to Gemini.

  Google rebranded Bard to Gemini in February 2024. This update ensures
  the link points to the current AI assistant.

  - Changed: `[Bard](https://bard.google.com/)`
  - To: `[Gemini](https://gemini.google.com/)`